### PR TITLE
Firebase REST API requires '.json' appended

### DIFF
--- a/lib/firebase/request.rb
+++ b/lib/firebase/request.rb
@@ -28,6 +28,7 @@ module Firebase
         raise "Please set Firebase.base_uri before making requests" unless Firebase.base_uri
 
         url = URI.join(Firebase.base_uri, path)
+        url = [url, '.json'].compact.join
 
         request = Typhoeus::Request.new(url.to_s,
                                         :body => options[:body],


### PR DESCRIPTION
I was getting errors when using firebase-ruby, and it seems that requests now must be appended with .json. See: http://www.firebase.com/docs/rest-api.html. Attached is a quick patch.
