### PR TITLE
Add support for writing to read-only namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ response.raw_body # => '{"name":"-INOQPH-aV_psbk3ZXEX"}'
 If you have a read-only namespace, set your secret key as follows:
 ```ruby
 Firebase.base_uri = 'http://gamma.firebase.com/youruser'
-Firebase.key = 'yoursecretkey'
+Firebase.auth = 'yoursecretkey'
 
 response = Firebase.push("todos", { :name => 'Pick the milk', :priority => 1 })
 ```

--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -4,15 +4,15 @@ module Firebase
   autoload :Request, 'firebase/request'
 
   class << self
-    attr_accessor :base_uri, :key
+    attr_accessor :base_uri, :auth
 
     def base_uri=(other)
       other = other + "/" if other[-1] != "/"
       @base_uri = other
     end
 
-    def key=(key)
-      @key = key
+    def auth=(auth)
+      @auth = auth
     end
 
     # Writes and returns the data

--- a/lib/firebase/request.rb
+++ b/lib/firebase/request.rb
@@ -26,7 +26,7 @@ module Firebase
       def build_url(path)
         host = Firebase.base_uri
         path = "#{path}.json"
-        query_string = Firebase.key ? "?key=#{Firebase.key}" : ""
+        query_string = Firebase.auth ? "?auth=#{Firebase.auth}" : ""
         url = URI.join(Firebase.base_uri, path, query_string)
 
         url.to_s

--- a/spec/firebase_request_spec.rb
+++ b/spec/firebase_request_spec.rb
@@ -18,11 +18,11 @@ describe "Firebase Request" do
   end
 
   describe "url_builder" do
-    it "should include a key in the query string, if configured" do
+    it "should include a auth in the query string, if configured" do
       Firebase.base_uri = 'https://test.firebaseio.com'
-      Firebase.key = 'secretkey'
+      Firebase.auth = 'secretkey'
 
-      Firebase::Request.build_url('users/eugene').should == 'https://test.firebaseio.com/users/eugene.json?key=secretkey'
+      Firebase::Request.build_url('users/eugene').should == 'https://test.firebaseio.com/users/eugene.json?auth=secretkey'
     end
   end
 end


### PR DESCRIPTION
This branch adds support for passing a secret key in the query string. The secret key is required for write access to protected namespaces (in beta right now).
