### PR TITLE
URI issue

### DIFF
--- a/lib/firebase/request.rb
+++ b/lib/firebase/request.rb
@@ -1,5 +1,6 @@
 require 'typhoeus'
 require 'json'
+require 'open-uri'
 
 module Firebase
   class Request


### PR DESCRIPTION
When I pulled the gem down to demo the gem, I got an error on the URI call.  Requiring 'open-uri' will keep others from getting that error.
