### PR TITLE
Use new URI scheme in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem install firebase
 
 
 ```ruby
-Firebase.base_uri = 'http://<your-firebase>.firebaseio.com/'
+Firebase.base_uri = 'https://<your-firebase>.firebaseio.com/'
 
 response = Firebase.push("todos", { :name => 'Pick the milk', :priority => 1 })
 response.success? # => true
@@ -29,7 +29,7 @@ response.raw_body # => '{"name":"-INOQPH-aV_psbk3ZXEX"}'
 
 If you have a read-only namespace, set your secret key as follows:
 ```ruby
-Firebase.base_uri = 'http://<your-firebase>.firebaseio.com/'
+Firebase.base_uri = 'https://<your-firebase>.firebaseio.com/'
 Firebase.auth = 'yoursecretkey'
 
 response = Firebase.push("todos", { :name => 'Pick the milk', :priority => 1 })


### PR DESCRIPTION
We switched to using [firebase].firebaseio.com instead of gamma.firebaseio.com/[username], updating README to reflect this!
