### PR TITLE
Fix memory leak with Typhoeus

### DIFF
--- a/lib/firebase/request.rb
+++ b/lib/firebase/request.rb
@@ -42,12 +42,12 @@ module Firebase
       def process(method, path, options={})
         raise "Please set Firebase.base_uri before making requests" unless Firebase.base_uri
 
+	@@hydra ||= Typhoeus::Hydra.new
         request = Typhoeus::Request.new(build_url(path),
                                         :body => options[:body],
                                         :method => method)
-        hydra = Typhoeus::Hydra.new
-        hydra.queue(request)
-        hydra.run
+        @@hydra.queue(request)
+        @@hydra.run
 
         new request.response
       end


### PR DESCRIPTION
Creating a new Typhoeus::Hydra object upon every request was causing massive memory leaks inside of our Sidekiq queues.
