### PR TITLE
Fixes exception if response.body is "null"

### DIFF
--- a/lib/firebase/request.rb
+++ b/lib/firebase/request.rb
@@ -42,7 +42,7 @@ module Firebase
       def process(method, path, options={})
         raise "Please set Firebase.base_uri before making requests" unless Firebase.base_uri
 
-	@@hydra ||= Typhoeus::Hydra.new
+	      @@hydra ||= Typhoeus::Hydra.new
         request = Typhoeus::Request.new(build_url(path),
                                         :body => options[:body],
                                         :method => method)
@@ -62,6 +62,8 @@ module Firebase
 
     def body
       JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      response.body == 'null' ? nil : raise
     end
 
     def raw_body

--- a/spec/firebase_spec.rb
+++ b/spec/firebase_spec.rb
@@ -24,6 +24,19 @@ describe "Firebase" do
       Firebase::Request.should_receive(:get).with('users/info')
       Firebase.get('users/info')
     end
+
+    it "return nil if response body contains 'null'" do
+      mock_response = mock(:body => 'null')
+      @request = Firebase::Request.new(mock_response)
+      expect { @request.body }.to_not raise_error(JSON::ParserError)
+    end
+
+    it "raises JSON::ParserError if response body contains invalid JSON" do
+      mock_response = mock(:body => '{"this is wrong"')
+      @request = Firebase::Request.new(mock_response)
+      expect { @request.body }.to raise_error(JSON::ParserError)
+    end
+
   end
 
   describe "push" do


### PR DESCRIPTION
If you do a get() on a path that doesn't exist, the response.body = "null", which raises a JSON::ParserError:

```
irb(main):021:0> r.body
JSON::ParserError: 757: unexpected token at 'null'
```

This patch fixes this by check if the response.body == 'null'. If so, it returns nil, otherwise it re-raises the JSON::ParserError.

```
irb(main):002:0> r.body
=> nil
```
