### PR TITLE
Add in ability to create instances of Firebase

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    coderay (1.1.0)
     diff-lcs (1.1.3)
     ethon (0.5.9)
       ffi (~> 1.2.0)
@@ -13,7 +14,12 @@ GEM
       rake
       rdoc
     json (1.7.0)
+    method_source (0.8.2)
     mime-types (1.21)
+    pry (0.9.12.3)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
@@ -25,6 +31,7 @@ GEM
     rspec-expectations (2.9.1)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.9.0)
+    slop (3.4.7)
     typhoeus (0.6.1)
       ethon (~> 0.5.9)
 
@@ -34,5 +41,6 @@ PLATFORMS
 DEPENDENCIES
   jeweler (~> 1.8.3)
   json
+  pry
   rspec
   typhoeus (>= 0.6.1)

--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -1,5 +1,4 @@
-
-module Firebase
+class Firebase
 
   autoload :Request, 'firebase/request'
 
@@ -7,10 +6,13 @@ module Firebase
     attr_accessor :base_uri, :auth
 
     def base_uri=(other)
-      if other # Guard from nil
-        other = other + "/" if other[-1] != "/"
+      @base_uri = format_uri(other)
+    end
+
+    def format_uri(other)
+      if other
+        other.end_with?("/") ? other : other + '/'
       end
-      @base_uri = other
     end
 
     def auth=(auth)
@@ -46,4 +48,55 @@ module Firebase
     end
 
   end
+
+  
+  attr_accessor :auth
+  attr_reader :base_uri
+
+  def initialize(base_uri = Firebase.base_uri, auth = Firebase.auth)
+    @base_uri = base_uri
+    @auth = auth
+  end
+
+  def base_uri=(str)
+    @base_uri = Firebase.format_uri(str)
+  end  
+
+  def set_base_uri
+    Firebase::Request.set_uri(@base_uri)
+  end
+
+  def set_auth
+    Firebase::Request.set_auth(@auth)
+  end
+
+  def set_request
+    set_base_uri
+    set_auth
+  end
+
+  def set(path, data)
+    set_request
+    Firebase.set(path, data)
+  end
+
+  def get(path)
+    set_request
+    Firebase.get(path)
+  end
+
+  def push(path, data)
+    set_request
+    Firebase.push(path, data)
+  end
+
+  def delete(path)
+    Firebase.delete(path)
+  end
+
+  def update(path, data)
+    Firebase.update(path, data)
+  end
+
 end
+

--- a/lib/firebase/request.rb
+++ b/lib/firebase/request.rb
@@ -3,10 +3,26 @@ require 'json'
 require 'open-uri'
 require 'uri'
 
-module Firebase
+class Firebase
   class Request
 
     class << self
+
+      def set_uri(uri)
+        @uri = uri
+      end
+
+      def reset_uri
+        @uri = nil
+      end
+
+      def set_auth(auth)
+        @auth = auth
+      end
+
+      def reset_auth
+        @auth = nil
+      end
 
       def get(path)
         process(:get, path)
@@ -29,10 +45,12 @@ module Firebase
       end
 
       def build_url(path)
-        host = Firebase.base_uri
+        host = @uri || Firebase.base_uri
         path = "#{path}.json"
-        query_string = Firebase.auth ? "?auth=#{Firebase.auth}" : ""
-        url = URI.join(Firebase.base_uri, path, query_string)
+        query_string = @auth || Firebase.auth ? "?auth=#{@auth || Firebase.auth}" : ""
+        url = URI.join(host, path, query_string)
+        reset_uri
+        reset_auth
 
         url.to_s
       end
@@ -40,7 +58,7 @@ module Firebase
       private
 
       def process(method, path, options={})
-        raise "Please set Firebase.base_uri before making requests" unless Firebase.base_uri
+        raise "Please set Firebase.base_uri before making requests" unless Firebase.base_uri || @uri
 
 	      @@hydra ||= Typhoeus::Hydra.new
         request = Typhoeus::Request.new(build_url(path),

--- a/spec/firebase_instance_spec.rb
+++ b/spec/firebase_instance_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'an instance of Firebase' do
+
+  let (:data) do
+    { 'name' => 'Oscar' }
+  end
+
+  let(:instance) {Firebase.new('https://test.firebaseio.com')}
+
+  describe 'instance set' do
+    it "writes and returns the data" do
+      Firebase::Request.should_receive(:put).with('users/info', data)
+      instance.set('users/info', data)
+    end
+  end
+
+  describe 'instance get' do
+    it 'returns the data' do
+      Firebase::Request.should_receive(:get).with('users/info')
+      instance.get('users/info')
+    end
+  end
+
+  describe 'instance push' do
+    it 'writes the data' do
+      Firebase::Request.should_receive(:post).with('users', data)
+      instance.push('users', data)
+    end
+  end
+
+  describe "instance delete" do
+    it "returns true" do
+      Firebase::Request.should_receive(:delete).with('users/info')
+      instance.delete('users/info')
+    end
+  end
+
+  describe "instance update" do
+    it "updates the data" do
+      Firebase::Request.should_receive(:patch).with('users/info', data)
+      instance.update('users/info', data)
+    end
+  end
+
+end

--- a/spec/firebase_request_spec.rb
+++ b/spec/firebase_request_spec.rb
@@ -4,6 +4,7 @@ describe "Firebase Request" do
 
   after do
     Firebase.base_uri = nil
+    Firebase.auth = nil
   end
 
   describe "url_builder" do
@@ -20,6 +21,34 @@ describe "Firebase Request" do
       Firebase::Request.build_url('users/eugene').should == 'https://test.firebaseio.com/users/eugene.json'
     end
   end
+
+  describe "url_builder for FirebaseInstance" do
+    it "should build the correct url when an instance calls it" do
+      Firebase.base_uri = 'https://test.firebaseio.com'
+      firebase_instance = Firebase.new("https://instance.firebaseio.com")
+      firebase_instance.set_base_uri
+
+      Firebase::Request.build_url('users/eugene').should == 'https://instance.firebaseio.com/users/eugene.json'
+
+    end
+
+    it "should default to Firebase.base_uri if none is given to the instance" do
+      Firebase.base_uri = 'https://test.firebaseio.com'
+      firebase_instance = Firebase.new
+      firebase_instance.set_base_uri
+
+      Firebase::Request.build_url('users/eugene').should == 'https://test.firebaseio.com/users/eugene.json'
+    end
+  end
+  
+  describe "auth for FirebaseInstance" do
+    it "should use the auth passed from the instance" do
+      Firebase.base_uri = 'https://test.firebaseio.com'
+      firebase_instance = Firebase.new(nil, 'secretkey')
+      firebase_instance.set_auth
+      Firebase::Request.build_url('users/eugene').should == 'https://test.firebaseio.com/users/eugene.json?auth=secretkey'
+    end
+  end 
 
   describe "url_builder" do
     it "should include a auth in the query string, if configured" do


### PR DESCRIPTION
This is a fix for #12. It adds in the ability to create an instance of Firebase that can accept a base_uri as well as an auth_token. If not provided it will default to the values set on Firebase itself. This maintains backwards compatibilty
