### PR TITLE
Turn Firebase into a module and add a Client class.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       multi_xml (~> 0.5)
       rack (~> 1.2)
     rack (1.5.2)
-    rake (10.1.0)
+    rake (10.1.1)
     rdoc (4.0.1)
       json (~> 1.4)
     rspec (2.14.1)

--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -1,57 +1,58 @@
-class Firebase
+module Firebase
+  class Client
 
-  require 'firebase/request'
-  require 'firebase/response'
+    require 'firebase/request'
+    require 'firebase/response'
 
-  class << self
-    def format_uri(other)
-      if other
-        other.end_with?("/") ? other : other + '/'
+    class << self
+      def format_uri(other)
+        if other
+          other.end_with?("/") ? other : other + '/'
+        end
       end
     end
-  end
 
-  attr_reader :auth, :request
+    attr_reader :auth, :request
 
-  def initialize(base_uri, auth=nil)
-    uri = Firebase.format_uri(base_uri)
-    @request = Firebase::Request.new(uri)
-    @auth = auth
-  end
+    def initialize(base_uri, auth=nil)
+      uri = Firebase::Client.format_uri(base_uri)
+      @request = Firebase::Request.new(uri)
+      @auth = auth
+    end
 
     # Writes and returns the data
     #   Firebase.set('users/info', { 'name' => 'Oscar' }) => { 'name' => 'Oscar' }
-  def set(path, data, query={})
-    request.put(path, data, query_options(query))
+    def set(path, data, query={})
+      request.put(path, data, query_options(query))
+    end
+
+    # Returns the data at path
+    def get(path, query={})
+      request.get(path, query_options(query))
+    end
+
+    # Writes the data, returns the key name of the data added
+    #   Firebase.push('users', { 'age' => 18}) => {"name":"-INOQPH-aV_psbk3ZXEX"}
+    def push(path, data, query={})
+      request.post(path, data, query_options(query))
+    end
+
+    # Deletes the data at path and returs true
+    def delete(path, query={})
+      request.delete(path, query_options(query))
+    end
+
+    # Write the data at path but does not delete ommited children. Returns the data
+    #   Firebase.update('users/info', { 'name' => 'Oscar' }) => { 'name' => 'Oscar' }
+    def update(path, data, query={})
+      request.patch(path, data, query_options(query))
+    end
+
+    private
+
+    def query_options(query)
+      { :auth => auth }.merge(query)
+    end
   end
-
-  # Returns the data at path
-  def get(path, query={})
-    request.get(path, query_options(query))
-  end
-
-  # Writes the data, returns the key name of the data added
-  #   Firebase.push('users', { 'age' => 18}) => {"name":"-INOQPH-aV_psbk3ZXEX"}
-  def push(path, data, query={})
-    request.post(path, data, query_options(query))
-  end
-
-  # Deletes the data at path and returs true
-  def delete(path, query={})
-    request.delete(path, query_options(query))
-  end
-
-  # Write the data at path but does not delete ommited children. Returns the data
-  #   Firebase.update('users/info', { 'name' => 'Oscar' }) => { 'name' => 'Oscar' }
-  def update(path, data, query={})
-    request.patch(path, data, query_options(query))
-  end
-
-  private
-
-  def query_options(query)
-    { :auth => auth }.merge(query)
-  end
-
 end
 

--- a/lib/firebase/request.rb
+++ b/lib/firebase/request.rb
@@ -3,7 +3,7 @@ require 'json'
 require 'open-uri'
 require 'uri'
 
-class Firebase
+module Firebase
   class Request
 
     attr_reader :base_uri

--- a/lib/firebase/response.rb
+++ b/lib/firebase/response.rb
@@ -1,4 +1,4 @@
-class Firebase
+module Firebase
   class Response
 
     attr_accessor :response

--- a/spec/firebase_spec.rb
+++ b/spec/firebase_spec.rb
@@ -7,7 +7,7 @@ describe "Firebase" do
   end
 
   before do
-    @firebase = Firebase.new('https://test.firebaseio.com')
+    @firebase = Firebase::Client.new('https://test.firebaseio.com')
     @req = @firebase.request
   end
 
@@ -72,7 +72,7 @@ describe "Firebase" do
 
   describe "options" do
     it "passes custom options" do
-      firebase = Firebase.new('https://test.firebaseio.com', 'secret')
+      firebase = Firebase::Client.new('https://test.firebaseio.com', 'secret')
       firebase.request.should_receive(:get).with('todos', {:auth => 'secret', :foo => 'bar'})
       firebase.get('todos', :foo => 'bar')
     end


### PR DESCRIPTION
firebase-ruby currently conflicts with https://github.com/firebase/firebase-token-generator-ruby supplied by Firebase for custom authentication because in firebase-ruby Firebase is a class but in firebase-token-generator-ruby Firebase is a module.

This commit adds Firebase as a module to firebase-ruby and turns the existing code into a Client class so that you have...

```
Firebase::Client.new(...)
```
