### PR TITLE
Support for adding Firebase server timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ base_uri = 'https://<your-firebase>.firebaseio.com/'
 
 firebase = Firebase::Client.new(base_uri)
 
-response = firebase.push("todos", { :name => 'Pick the milk', :priority => 1 })
+response = firebase.push("todos", { :name => 'Pick the milk', :priority => 1, :created => Firebase::ServerValue::TIMESTAMP })
 response.success? # => true
 response.code # => 200
 response.body # => { 'name' => "-INOQPH-aV_psbk3ZXEX" }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ base_uri = 'https://<your-firebase>.firebaseio.com/'
 
 firebase = Firebase::Client.new(base_uri)
 
-response = firebase.push("todos", { :name => 'Pick the milk', :priority => 1, :created => Firebase::ServerValue::TIMESTAMP })
+response = firebase.push("todos", { :name => 'Pick the milk', :priority => 1 })
 response.success? # => true
 response.code # => 200
 response.body # => { 'name' => "-INOQPH-aV_psbk3ZXEX" }
@@ -39,6 +39,12 @@ You can now pass custom query options to firebase:
 response = firebase.push("todos", :limit => 1)
 ```
 
+To populate a value with a Firebase server timestamp, you can pass in a key of ```Firebase::ServerValue::TIMESTAMP```:
+
+```ruby
+response = firebase.push("todos", { :name => 'Pick the milk', :created => Firebase::ServerValue::TIMESTAMP })
+```
+
 So far, supported methods are:
 
 ```ruby
@@ -56,4 +62,3 @@ More information about Firebase and the Firebase API is available at the
 
 Copyright (c) 2013 Oscar Del Ben. See LICENSE.txt for
 further details.
-

--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'firebase/request'
 require 'firebase/response'
+require 'firebase/server_value'
 
 module Firebase
   class Client

--- a/lib/firebase/server_value.rb
+++ b/lib/firebase/server_value.rb
@@ -1,0 +1,5 @@
+module Firebase
+  class ServerValue
+    TIMESTAMP = { :"sv" => 'timestamp' } 
+  end
+end


### PR DESCRIPTION
Using the firebase-ruby gem, we found ourselves needing to add timestamp support, which is available through Firebase's JS libraries but not in the firebase-ruby gem.  The structure mimics the JS libraries' timestamp structure for consistency.