### PR TITLE
fix to server timestamp

### DIFF
--- a/lib/firebase/server_value.rb
+++ b/lib/firebase/server_value.rb
@@ -1,5 +1,5 @@
 module Firebase
   class ServerValue
-    TIMESTAMP = { :"sv" => 'timestamp' } 
+    TIMESTAMP = { ".sv" => 'timestamp' } 
   end
 end


### PR DESCRIPTION
When I tried the existing code on master, timestamps were just getting saved as the string "timestamp". It was a little problem with the "sv" syntax.

https://www.firebase.com/docs/rest/api/#section-server-values