### PR TITLE
Use Net::HTTP instead of HTTPClient

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "http://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem 'httpclient'
 gem 'json'
 
 # Add dependencies to develop your gem here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,6 @@ GEM
       oauth2
     hashie (3.4.3)
     highline (1.7.8)
-    httpclient (2.7.0.1)
     jeweler (2.0.1)
       builder
       bundler (>= 1.0)
@@ -65,9 +64,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  httpclient
   jeweler
   json
   rake
   rdoc
   rspec
+
+BUNDLED WITH
+   1.13.6

--- a/firebase.gemspec
+++ b/firebase.gemspec
@@ -46,20 +46,17 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, [">= 0"])
       s.add_runtime_dependency(%q<json>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
     else
-      s.add_dependency(%q<httpclient>, [">= 0"])
       s.add_dependency(%q<json>, [">= 0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rdoc>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
     end
   else
-    s.add_dependency(%q<httpclient>, [">= 0"])
     s.add_dependency(%q<json>, [">= 0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rdoc>, [">= 0"])

--- a/lib/firebase/response.rb
+++ b/lib/firebase/response.rb
@@ -15,11 +15,11 @@ module Firebase
     end
 
     def success?
-      [200, 204].include? response.status
+      [200, 204].include? code
     end
 
     def code
-      response.status
+      response.code.to_i
     end
   end
 end

--- a/spec/firebase_spec.rb
+++ b/spec/firebase_spec.rb
@@ -121,11 +121,7 @@ describe "Firebase" do
   describe "http processing" do
     it "sends custom auth" do
       firebase = Firebase::Client.new('https://test.firebaseio.com', 'secret')
-      expect(firebase.request).to receive(:request).with(:get, "todos.json", {
-        :body => nil,
-        :query => {:auth => "secret", :foo => 'bar'},
-        :follow_redirect => true
-      })
+      expect(firebase.request).to receive(:request).with(an_instance_of(Net::HTTP::Get))
       firebase.get('todos', :foo => 'bar')
     end
   end


### PR DESCRIPTION
This branch is a direct replacement of HTTPClient with Net::HTTP.

Net::HTTP does not use Timeout.timeout for connection and read timeouts (whereas HTTPClient does).  This is pretty important in multi-threaded environments.  See the following articles for solid condemnation of Timeout.timeout:

* http://blog.headius.com/2008/02/ruby-threadraise-threadkill-timeoutrb.html
* https://coderwall.com/p/1novga/ruby-timeouts-are-dangerous
* https://www.reddit.com/r/programming/comments/3ui1sw/why_rubys_timeout_is_dangerous_and_threadraise_is/cxfg98b/