### PR TITLE
use new firebase admin sdk private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ response.raw_body # => '{"name":"-INOQPH-aV_psbk3ZXEX"}'
 If you have a read-only namespace, set your secret key as follows:
 ```ruby
 # Using Firebase Admin SDK private key
-firebase = Firebase::Client.new(base_uri, "/path/to/private_key.json")
+firebase = Firebase::Client.new(base_uri, private_key_json_string)
 
 # Using Firebase Database Secret (deprecated)
 firebase = Firebase::Client.new(base_uri, db_secret)

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ response.raw_body # => '{"name":"-INOQPH-aV_psbk3ZXEX"}'
 
 If you have a read-only namespace, set your secret key as follows:
 ```ruby
-firebase = Firebase::Client.new(base_uri, secret_key)
+# Using Firebase Admin SDK private key
+firebase = Firebase::Client.new(base_uri, "/path/to/private_key.json")
 
-response = firebase.push("todos", { :name => 'Pick the milk', :'.priority' => 1 })
+# Using Firebase Database Secret (deprecated)
+firebase = Firebase::Client.new(base_uri, db_secret)
 ```
 
 You can now pass custom query options to firebase:

--- a/firebase.gemspec
+++ b/firebase.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'httpclient', '>= 2.5.3'
   s.add_runtime_dependency 'json'
+  s.add_runtime_dependency 'googleauth'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rspec'

--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -17,10 +17,10 @@ module Firebase
       default_header = {
         'Content-Type' => 'application/json'
       }
-      if auth && File.file?(auth)
-        # Using Admin SDK private key file
+      if auth && valid_json?(auth)
+        # Using Admin SDK private key
         scopes = %w(https://www.googleapis.com/auth/firebase.database https://www.googleapis.com/auth/userinfo.email)
-        credentials = Google::Auth::DefaultCredentials.make_creds(json_key_io: File.open(auth), scope: scopes)
+        credentials = Google::Auth::DefaultCredentials.make_creds(json_key_io: StringIO.new(auth), scope: scopes)
         default_header = credentials.apply(default_header)
       else
         # Using deprecated Database Secret
@@ -71,6 +71,15 @@ module Firebase
         :query            => (@auth ? { :auth => @auth }.merge(query) : query),
         :follow_redirect  => true
       })
+    end
+
+    def valid_json?(json)
+      begin
+        JSON.parse(json)
+        return true
+      rescue JSON::ParserError
+        return false
+      end
     end
   end
 end

--- a/spec/firebase_spec.rb
+++ b/spec/firebase_spec.rb
@@ -133,13 +133,13 @@ describe "Firebase" do
       })
       firebase.get('todos', :foo => 'bar')
     end
-    
+
     it "sets custom auth header" do
-      expect(File).to receive(:file?).with('test_private_key.json').and_return(true)
-      expect(File).to receive(:open).with('test_private_key.json').and_return('private key')
+      private_key = '{ "private_key": true }'
       credentials = double()
       expect(credentials).to receive(:apply).with({ 'Content-Type' => 'application/json' }).and_return({ :authorization => 'Bearer abcdef', 'Content-Type' => 'application/json' })
-      expect(Google::Auth::DefaultCredentials).to receive(:make_creds).with(json_key_io: 'private key', scope: instance_of(Array)).and_return(credentials)
+      expect(StringIO).to receive(:new).with(private_key).and_return('StringIO private key')
+      expect(Google::Auth::DefaultCredentials).to receive(:make_creds).with(json_key_io: 'StringIO private key', scope: instance_of(Array)).and_return(credentials)
       expect(HTTPClient).to receive(:new).with({
         :base_url => 'https://test.firebaseio.com/',
         :default_header => {
@@ -147,7 +147,7 @@ describe "Firebase" do
           'Content-Type' => 'application/json'
         }
       })
-      firebase = Firebase::Client.new('https://test.firebaseio.com/', 'test_private_key.json')
+      Firebase::Client.new('https://test.firebaseio.com/', private_key)
     end
   end
 end


### PR DESCRIPTION
To maintain backwards compatibility, I kept the same `auth` parameter. If it's a filepath, treat it as an Admin SDK private key file. Otherwise, treat it as a database secret key.

Fixes #64, #80 