### PR TITLE
Convert from HTTPClient to Faraday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.8.1 (faraday)
+
+* Switch to `faraday` client from `HTTPClient` because HTTPclient does not support https proxies.
+
 ## 0.2.8
 
 * Fix [auth token expiration](https://github.com/oscardelben/firebase-ruby/pull/84) on longer lived Firebase objects.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ update(path, data, query_options)
 
 ### Configuring HTTP options
 
-[httpclient](https://github.com/nahi/httpclient) is used under the covers to make HTTP requests.
+[Faraday](https://github.com/lostisland/faraday) is used under the covers to make HTTP requests.
+This conversion is TODO, as it is not needed for my purposes.
 You may find yourself wanting to tweak the timeout settings. By default, `httpclient` uses
 some [sane defaults](https://github.com/nahi/httpclient/blob/dd322d39d4d11c48f7bbbc05ed6273ac912d3e3b/lib/httpclient/session.rb#L138),
 but it is quite easy to change them by modifying the `request` object directly:

--- a/firebase.gemspec
+++ b/firebase.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.summary = "Firebase wrapper for Ruby"
 
   s.add_runtime_dependency 'faraday'
+  s.add_runtime_dependency 'faraday_middleware'
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'googleauth'
   s.add_development_dependency 'rake'

--- a/firebase.gemspec
+++ b/firebase.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.summary = "Firebase wrapper for Ruby"
 
-  s.add_runtime_dependency 'httpclient', '>= 2.5.3'
+  s.add_runtime_dependency 'faraday'
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'googleauth'
   s.add_development_dependency 'rake'

--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -1,7 +1,7 @@
 require 'firebase/response'
 require 'firebase/server_value'
 require 'googleauth'
-require 'httpclient'
+require 'faraday'
 require 'json'
 require 'uri'
 
@@ -14,12 +14,7 @@ module Firebase
         raise ArgumentError.new('base_uri must be a valid https uri')
       end
       base_uri += '/' unless base_uri.end_with?('/')
-      @request = HTTPClient.new({
-        :base_url => base_uri,
-        :default_header => {
-          'Content-Type' => 'application/json'
-        }
-      })
+      @request = Faraday.new(url: base_uri, headers: { 'Content-Type' => 'application/json' })
       if auth && valid_json?(auth)
         # Using Admin SDK service account
         @credentials = Google::Auth::DefaultCredentials.make_creds(

--- a/lib/firebase/version.rb
+++ b/lib/firebase/version.rb
@@ -1,3 +1,3 @@
 module Firebase
- VERSION = '0.2.8'.freeze
+  VERSION = '0.2.8.1'.freeze
 end


### PR DESCRIPTION
We’re switching from a Hurley/Faraday-based mechanism to the firebase-ruby gem because it provides a REALLY nice interface for the new auth mechanism without me actually having to do a lot of heavy lifting. At least until I got it to one of our production-like test environments, when it failed because it does not support HTTPS proxies (https_proxy), which our previous mechanism did handle. I traced this to the use of `httpclient`.

Unfortunately, Nahi’s HTTPClient has not been modified in two years and I see no open PRs for https proxy support, something that is supported in Net::HTTP (which is all we use in Hurley and Faraday).

This PR is to provide all of the changes necessary to switch from httpclient to Faraday using the default adapter. For a variety of reasons, I had to make a few more changes than I would have liked to, and I consider this an incomplete change overall. There are a couple of things that I normally wouldn’t do on behalf of a maintainer (like updating the VERSION), but I’m stuck in a situation where I needed to deploy this to our private gem server. I am also in the middle of our live tests for this, so there may be further changes, but it looks good so far in local testing (*just like last time*).

The existing behaviour can be more-or-less maintained by changing from `Faraday.default_adapter` to `:http_client`, but I see no reason to do that since Net::HTTP is under active development on Ruby.

The dinosaurs test is failing on master, BTW, so I’ve at least got this part all green.