### PR TITLE
Add `require 'firebase'` to the README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ gem install firebase
 ## Usage
 
 ```ruby
+require 'firebase'
+
 base_uri = 'https://<your-firebase>.firebaseio.com/'
 
 firebase = Firebase::Client.new(base_uri)


### PR DESCRIPTION
It's a simple step, and can be inferred, but I think it's nice to
include a whole block that will execute.