### PR TITLE
Travis: Drop Ruby 1.9, Add Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: ruby
 rvm:
- - 2.1
- - 2.2
  - 2.3
  - 2.4
  - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
- - 1.9
  - 2.1
  - 2.2
  - 2.3
  - 2.4
  - 2.5
+ - 2.6


### PR DESCRIPTION
Ruby 1.9 has been EOL for over 4 years, so I think it's fine to remove
it from the travis matrix.

This also adds Ruby 2.6 to ensure it continues to work in the future.