### PR TITLE
Remove value check causing errors with `false`.

### DIFF
--- a/lib/firebase.rb
+++ b/lib/firebase.rb
@@ -76,7 +76,7 @@ module Firebase
       end
 
       Firebase::Response.new @request.request(verb, "#{path}.json", {
-        :body             => (data && data.to_json),
+        :body             => data.to_json,
         :query            => (@secret ? { :auth => @secret }.merge(query) : query),
         :follow_redirect  => true
       })


### PR DESCRIPTION
There's no need to check for the existence of `data` because `.to_json` returns `"null"` if `data` is `nil`, and the check forbids setting a value of `false`.

For example, doing `firebase.set("some/path", false)` returns `{"error"=>"No data supplied."}`.