### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/firebase.gemspec
+++ b/firebase.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     "lib/firebase/server_value.rb",
     "lib/firebase/version.rb"
   ]
-  s.homepage = "http://github.com/oscardelben/firebase-ruby"
+  s.homepage = "https://github.com/oscardelben/firebase-ruby"
   s.licenses = ["MIT"]
   s.summary = "Firebase wrapper for Ruby"
 


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/firebase or some tools or APIs that use the gem's metadata.