### PR TITLE
Add support for the server value - 'increment'

### DIFF
--- a/lib/firebase/server_value.rb
+++ b/lib/firebase/server_value.rb
@@ -1,5 +1,9 @@
 module Firebase
   class ServerValue
     TIMESTAMP = { '.sv' => 'timestamp' }.freeze
+
+    def self.increment amount
+      {'.sv' => { 'increment' => amount } }
+    end
   end
 end

--- a/spec/firebase_spec.rb
+++ b/spec/firebase_spec.rb
@@ -141,4 +141,14 @@ describe "Firebase" do
       })
     end
   end
+
+  describe "server values" do
+    let (:increment) do
+      {'.sv' => { 'increment' => 1 } }
+    end
+    it "should increment" do
+      expect(@firebase).to receive(:process).with(:put, 'users/info', increment, {})
+      @firebase.set('users/info', Firebase::ServerValue.increment(1))
+    end
+  end
 end


### PR DESCRIPTION
Though the docs at https://firebase.google.com/docs/database/rest/save-data mention
`"timestamp" is the only supported server value, and is the time since the UNIX epoch in milliseconds. `,
it is mentioned in the [RESP API Reference](https://firebase.google.com/docs/reference/rest/database#section-server-values) that it also supports increment.

This PR adds support for that.