### PR TITLE
Add support for transaction

### DIFF
--- a/lib/firebase/response.rb
+++ b/lib/firebase/response.rb
@@ -21,5 +21,9 @@ module Firebase
     def code
       response.status
     end
+
+    def etag
+      response.headers['ETag']
+    end
   end
 end


### PR DESCRIPTION
Added support for transaction using [Conditional Requests](https://firebase.google.com/docs/reference/rest/database#section-conditional-requests) and [ETag](https://firebase.google.com/docs/reference/rest/database#section-cond-etag) similar to the [JS implementation](https://firebase.google.com/docs/reference/js/database.md#runtransaction_a3641e5)